### PR TITLE
it is expected that tx_line goes low after a reset (accoding to UART …

### DIFF
--- a/v2/cores/osdvu/uart.v
+++ b/v2/cores/osdvu/uart.v
@@ -136,6 +136,7 @@
         if (rst) begin
             recv_state = RX_IDLE;
             tx_state = TX_IDLE;
+            tx_out = 1;
         end
                               
         // Countdown timers for the receiving and transmitting


### PR DESCRIPTION
According to UART spec, tx_line should stay high after reset? (not sure, rather asking)

Hello. I want to use the uart module you created in one of my projects. I observed that when I issue a reset, shortly after a transaction has begun, the tx_line goes low and remains low (see red arrow at the right part of the image). It is expected? If no, I proposed a quick fix.

Also, I see on waveforms that stop bits on tx line are not generated so visible...  What could be the reason? (see left part of image, where I've written which data I'd want to send)

![err](https://user-images.githubusercontent.com/11389563/72226390-4b6e2700-3599-11ea-8442-8a439b710c73.JPG)

I can share with you my code (actually is derived from your testbench code, besides an adapter that I've added) and screenshot from Modelsim.

[test uart_transmitter_adapter.zip](https://github.com/wd5gnr/icestickPWM/files/4051608/test.uart_transmitter_adapter.zip)


Thank you,
Alexandru Dinu